### PR TITLE
Feat/kakao map

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "eslint-config-airbnb": "^19.0.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-kakao-maps-sdk": "^1.1.24",
     "react-router-dom": "^6.18.0",
     "styled-components": "^6.1.0",
     "vite-plugin-svgr": "^4.1.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,11 +2,14 @@ import { RouterProvider } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import { routers } from '@/router';
 import theme from '@/styles/theme';
+import RootLayout from './styles/RootLayout';
 
 export default function App() {
   return (
     <ThemeProvider theme={theme}>
-      <RouterProvider router={routers} />
+      <RootLayout>
+        <RouterProvider router={routers} />
+      </RootLayout>
     </ThemeProvider>
   );
 }

--- a/src/components/kakao-map/index.jsx
+++ b/src/components/kakao-map/index.jsx
@@ -1,0 +1,55 @@
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import { useEffect, useState } from 'react';
+import useKakaoMapLoader from './useKakaoMapLoader';
+
+export default function KakaoMap() {
+  useKakaoMapLoader();
+  const [location, setLocation] = useState({
+    center: {
+      lat: 33.450701,
+      lng: 126.570667,
+    },
+    errMsg: null,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    if (navigator.geolocation) {
+      // GeoLocation을 이용해서 접속 위치를 얻어옵니다
+      navigator.geolocation.getCurrentPosition(
+        position => {
+          setLocation(prev => ({
+            ...prev,
+            center: {
+              lat: position.coords.latitude, // 위도
+              lng: position.coords.longitude, // 경도
+            },
+            isLoading: false,
+          }));
+        },
+        err => {
+          setLocation(prev => ({
+            ...prev,
+            errMsg: err.message,
+            isLoading: false,
+          }));
+        },
+      );
+    } else {
+      // HTML5의 GeoLocation을 사용할 수 없을때 마커 표시 위치와 인포윈도우 내용을 설정합니다
+      setLocation(prev => ({
+        ...prev,
+        errMsg: 'geolocation을 사용할수 없습니다.',
+        isLoading: false,
+      }));
+    }
+  }, []);
+
+  return (
+    <Map
+      center={location.center}
+      style={{ width: '100%', height: '100vh' }}
+      level={3}
+    />
+  );
+}

--- a/src/components/kakao-map/useKakaoMapLoader.jsx
+++ b/src/components/kakao-map/useKakaoMapLoader.jsx
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { useKakaoLoader } from 'react-kakao-maps-sdk';
+
+export default function useKakaoMapLoader() {
+  return useKakaoLoader({
+    /**
+     * ※주의※ appkey의 경우 본인의 appkey를 사용하셔야 합니다.
+     * 해당 키는 docs를 위해 발급된 키 이므로, 임의로 사용하셔서는 안됩니다.
+     *
+     * @참고 https://apis.map.kakao.com/web/guide/
+     */
+    appkey: import.meta.env.VITE_KAKAO_JAVASCRIPT_KEY,
+    libraries: ['clusterer', 'drawing', 'services'],
+  });
+}

--- a/src/components/layout/index.jsx
+++ b/src/components/layout/index.jsx
@@ -1,36 +1,13 @@
-import styled from 'styled-components';
 import { redirect } from 'react-router-dom';
 import { UserProvider } from '@/api/context/userContext';
 
 export default function GeneralLayout({ children, withAuth }) {
   // 인증이 필요한 페이지에서 로그인하지 않은 user는 로그인 페이지로 이동
+  console.log(withAuth);
   if (withAuth && !localStorage.getItem('access_token')) {
+    console.log('권한이 없습니다. 로그인 페이지로 이동합니다.');
     redirect('/login');
   }
 
-  return (
-    <UserProvider>
-      <GeneralLayoutWrapper>{children}</GeneralLayoutWrapper>
-    </UserProvider>
-  );
+  return <UserProvider>{children}</UserProvider>;
 }
-
-const GeneralLayoutWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-  position: relative;
-  text-align: center;
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-  /* 미디어 쿼리 적용 */
-  /* pc화면에서 너비를 390로 고정합니다*/
-  @media (hover: hover) {
-    width: 390px;
-    margin: 0 auto;
-  }
-  /* 스크롤바 숨기기 */
-  &::-webkit-scrollbar {
-    display: none;
-  }
-`;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -2,13 +2,14 @@ import { createBrowserRouter } from 'react-router-dom';
 import Main from '@/routes/main';
 import RedirectedKakao from '@/routes/auth/kakao';
 import Auth from '@/routes/auth';
-import GeneralLayout from './components/layout';
+import GeneralLayout from '@/components/layout';
+import Plogging from '@/routes/plogging/index';
 
 const routerData = [
   {
     path: '/',
     element: <Main />,
-    withAuth: true,
+    withAuth: false,
   },
   {
     path: '/login',
@@ -22,20 +23,9 @@ const routerData = [
   },
   {
     path: '/plogging',
-    element: <div>추가 예정</div>,
-    withAuth: true,
+    element: <Plogging />,
+    withAuth: false,
   },
 ];
 
-export const routers = createBrowserRouter(
-  routerData.map(router => {
-    return {
-      path: router.path,
-      element: (
-        <GeneralLayout withAuth={router.withAuth}>
-          {router.element}
-        </GeneralLayout>
-      ),
-    };
-  }),
-);
+export const routers = createBrowserRouter(routerData);

--- a/src/routes/plogging/index.jsx
+++ b/src/routes/plogging/index.jsx
@@ -1,0 +1,5 @@
+import KakaoMap from '@/components/kakao-map';
+
+export default function Plogging() {
+  return <KakaoMap />;
+}

--- a/src/styles/RootLayout.jsx
+++ b/src/styles/RootLayout.jsx
@@ -1,0 +1,25 @@
+import { styled } from 'styled-components';
+
+export default function RootLayout({ children }) {
+  return <RootLayoutWrapper>{children}</RootLayoutWrapper>;
+}
+
+const RootLayoutWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  position: relative;
+  text-align: center;
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+  /* 미디어 쿼리 적용 */
+  /* pc화면에서 너비를 390로 고정합니다*/
+  @media (hover: hover) {
+    width: 390px;
+    margin: 0 auto;
+  }
+  /* 스크롤바 숨기기 */
+  &::-webkit-scrollbar {
+    display: none;
+  }
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,7 +179,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.22.5"
 
-"@babel/runtime@^7.23.2":
+"@babel/runtime@^7.22.15", "@babel/runtime@^7.23.2":
   version "7.23.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.23.2.tgz#062b0ac103261d68a966c4c7baf2ae3e62ec3885"
   integrity sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==
@@ -2180,6 +2180,11 @@ json5@^2.2.3:
     object.assign "^4.1.4"
     object.values "^1.1.6"
 
+kakao.maps.d.ts@^0.1.39:
+  version "0.1.39"
+  resolved "https://registry.yarnpkg.com/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.39.tgz#dc30726531906d9c42b8f15d7404baa169b8255e"
+  integrity sha512-KXENJ8hHYtjb5G+0vf8TXx/PwWW4j5ndDiQTSMvGtF7EFWu2P3N/+Zivcj9/UKn3j29Iz/sIUaA7WL8Ug3IDGQ==
+
 keyv@^4.5.3:
   version "4.5.4"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.4.tgz#a879a99e29452f942439f2a405e3af8b31d4de93"
@@ -2644,6 +2649,14 @@ react-is@^16.13.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-kakao-maps-sdk@^1.1.24:
+  version "1.1.24"
+  resolved "https://registry.yarnpkg.com/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.24.tgz#a5dd065a808cdcdaaec1cd3081b2fda2f7c57e7c"
+  integrity sha512-leLbFwBj6zbTdDg6A9U7EwYT2oq0+2F+NHZSVTyCmmvyc4yt2zpRvUmcAt8I6h2SDUdgHbpvKAV1sZoRIxD4JQ==
+  dependencies:
+    "@babel/runtime" "^7.22.15"
+    kakao.maps.d.ts "^0.1.39"
 
 react-refresh@^0.14.0:
   version "0.14.0"


### PR DESCRIPTION
## :memo: 구현 내용

- /plogging 페이지 생성
- 카카오 맵 도입
- GeneralLayout: CSS와 기능(UI와 비즈니스 로직) 분리
  - styles/RootLayout.jsx에 UI 부여 및 App.jsx에서 일괄적용
  - 권한 필요 페이지 필터링 로직은 GeneralLayout에서 관리

## :heavy_exclamation_mark: 리뷰포인트

- components/kakao-map
- GeneralLayout

## :round_pushpin: 참고자료

- [react-kakao-maps-sdk - npmjs.com](https://www.npmjs.com/package/react-kakao-maps-sdk)

## :heavy_check_mark: 다음 작업목록

- [] geolocation 활용하려면 프론트 배포해야 테스트 가능(https에서만 가능)
- [] 지도에 마커 기능 추가, 플로깅 기능 추가 필요
