### PR TITLE
Feat/plogging path

### DIFF
--- a/src/api/context/ploggingContext.jsx
+++ b/src/api/context/ploggingContext.jsx
@@ -1,0 +1,63 @@
+import { createContext, useContext, useMemo, useState } from 'react';
+
+const PloggingStartContext = createContext();
+const PloggingValueContext = createContext();
+const PloggingActionsContext = createContext();
+
+export function usePloggingStart() {
+  const value = useContext(PloggingStartContext);
+  if (!value) {
+    throw new Error('usePloggingStart should be used within PloggingProvider');
+  }
+  return value;
+}
+
+export function usePloggingValue() {
+  const value = useContext(PloggingValueContext);
+  if (!value) {
+    throw new Error('usePloggingValue should be used within PloggingProvider');
+  }
+  return value;
+}
+
+export function usePloggingActions() {
+  const value = useContext(PloggingActionsContext);
+  if (!value) {
+    throw new Error(
+      'usePloggingActions should be used within PloggingProvider',
+    );
+  }
+  return value;
+}
+
+export function PloggingProvider({ children }) {
+  const [ploggingLocations, setPloggingLocations] = useState([]);
+  const [isPloggingStarted, setIsPloggingStarted] = useState(false);
+
+  function add({ lat, lng }) {
+    setPloggingLocations(prev => [
+      ...prev,
+      {
+        lat,
+        lng,
+      },
+    ]);
+    const body = JSON.stringify(ploggingLocations);
+    localStorage.setItem('plogging_path', body);
+  }
+
+  const ploggingStartValue = useMemo(
+    () => [isPloggingStarted, setIsPloggingStarted],
+    [isPloggingStarted, setIsPloggingStarted],
+  );
+
+  return (
+    <PloggingActionsContext.Provider value={add}>
+      <PloggingValueContext.Provider value={ploggingLocations}>
+        <PloggingStartContext.Provider value={ploggingStartValue}>
+          {children}
+        </PloggingStartContext.Provider>
+      </PloggingValueContext.Provider>
+    </PloggingActionsContext.Provider>
+  );
+}

--- a/src/api/plogging.js
+++ b/src/api/plogging.js
@@ -1,0 +1,23 @@
+import instance from './instance';
+
+export const addPlogging = async body => {
+  return await instance.post('/members/ploggings', body);
+};
+
+export const getSinglePloggingInfo = async ploggingId => {
+  const response = await instance.get(`/members/ploggins/${ploggindId}`);
+  return response.data;
+};
+
+export const getTrashcanList = async () => {
+  const response = await instance.get('/trashcan');
+  return response.data;
+};
+
+export const addNewTrashcan = async body => {
+  return await instance.post('/trashcan', body);
+};
+
+export const deleteTrashcan = async trashcanId => {
+  return await instance.delete('/trashcan', { trashcanId });
+};

--- a/src/components/kakao-map/index.jsx
+++ b/src/components/kakao-map/index.jsx
@@ -1,9 +1,14 @@
 import React, { useEffect, useState } from 'react';
-import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import { Map, MapMarker, Polyline } from 'react-kakao-maps-sdk';
 import useKakaoMapLoader from './useKakaoMapLoader';
 import trashCanMarker from '@/assets/icons/markers/trashCanMarker.png';
 import locationMarker from '@/assets/icons/markers/locationMarker.png';
-import instance from '@/api/auth';
+import {
+  usePloggingActions,
+  usePloggingStart,
+  usePloggingValue,
+} from '@/api/context/ploggingContext';
+import theme from '@/styles/theme';
 
 export default function KakaoMap() {
   useKakaoMapLoader();
@@ -16,18 +21,40 @@ export default function KakaoMap() {
     isLoading: true,
   });
   const [positions, setPositions] = useState([]);
+  const add = usePloggingActions();
+  const ploggingData = usePloggingValue();
+  const [isPloggingStarted] = usePloggingStart();
+
+  const watcher = navigator.geolocation.watchPosition(
+    position => {
+      setLocation(prev => ({
+        ...prev,
+        center: {
+          lat: position.coords.latitude, // 위도
+          lng: position.coords.longitude, // 경도
+        },
+        isLoading: false,
+      }));
+      add({
+        lat: position.coords.latitude, // 위도
+        lng: position.coords.longitude, // 경도
+      });
+    },
+    err => {
+      setLocation(prev => ({
+        ...prev,
+        errMsg: err.message,
+        isLoading: false,
+      }));
+    },
+    {
+      enableHighAccuracy: true,
+      timeout: 4000,
+      maximumAge: 0,
+    },
+  );
 
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const response = await instance.get('/trash');
-        setPositions(response.data);
-        console.log(response.data);
-      } catch (error) {
-        console.error('Error fetching trash can data:', error);
-      }
-    };
-
     if (navigator.geolocation) {
       // GeoLocation을 이용해서 접속 위치를 얻어옵니다
       navigator.geolocation.getCurrentPosition(
@@ -40,6 +67,10 @@ export default function KakaoMap() {
             },
             isLoading: false,
           }));
+          add({
+            lat: position.coords.latitude, // 위도
+            lng: position.coords.longitude, // 경도
+          });
         },
         err => {
           setLocation(prev => ({
@@ -48,8 +79,12 @@ export default function KakaoMap() {
             isLoading: false,
           }));
         },
+        {
+          enableHighAccuracy: false,
+          timeout: 4000,
+          maximumAge: 0,
+        },
       );
-      fetchData();
     } else {
       // HTML5의 GeoLocation을 사용할 수 없을때 마커 표시 위치와 인포윈도우 내용을 설정합니다
       setLocation(prev => ({
@@ -59,6 +94,17 @@ export default function KakaoMap() {
       }));
     }
   }, []);
+
+  const cleanUp = () => {
+    navigator.geolocation && navigator.geolocation.clearWatch(watcher);
+    localStorage.removeItem('plogging_path');
+  };
+
+  useEffect(() => {
+    if (isPloggingStarted === true) watcher;
+
+    return cleanUp;
+  }, [isPloggingStarted]);
 
   return (
     <Map
@@ -90,6 +136,15 @@ export default function KakaoMap() {
           }, // 마커이미지의 크기입니다
         }}
       />
+      {ploggingData && isPloggingStarted === true && (
+        <Polyline
+          path={[ploggingData]}
+          strokeWeight={8} // 선의 두께 입니다
+          strokeColor={theme.palette.green.dark} // 선의 색깔입니다
+          strokeOpacity={0.7} // 선의 불투명도 입니다 1에서 0 사이의 값이며 0에 가까울수록 투명합니다
+          strokeStyle={'solid'} // 선의 스타일입니다
+        />
+      )}
     </Map>
   );
 }

--- a/src/components/kakao-map/index.jsx
+++ b/src/components/kakao-map/index.jsx
@@ -9,8 +9,8 @@ export default function KakaoMap() {
   useKakaoMapLoader();
   const [location, setLocation] = useState({
     center: {
-      lat: 33.450701,
-      lng: 126.570667,
+      lat: 37.4025352267,
+      lng: 127.10082686151,
     },
     errMsg: null,
     isLoading: true,

--- a/src/components/plogging/trash.jsx
+++ b/src/components/plogging/trash.jsx
@@ -17,6 +17,7 @@ import trashcanAdd from '@/assets/icons/buttons/trashcanAdd.png';
 import trashcanDelete from '@/assets/icons/buttons/trashcanDelete.png';
 import AddTrashcanMarker from '@/components/plogging/addTrashcanMarker';
 import EndPlogging from './endPlogging';
+import { usePloggingStart } from '@/api/context/ploggingContext';
 
 const SquareWrapper = styled.div`
   width: 100vw;
@@ -116,6 +117,7 @@ function Trash() {
 
   const [addTrashcan, setAddTrashcan] = useState(false);
   const [endPloggingModalOpen, setEndPloggingModalOpen] = useState(false);
+  const [, setIsPloggingStarted] = usePloggingStart();
 
   const handleMinusClick = item => {
     if (counts[item] > 0) {
@@ -144,6 +146,7 @@ function Trash() {
 
   const handleConfirm = () => {
     setEndPloggingModalOpen(false);
+    setIsPloggingStarted(false);
     // 결과 페이지로 이동
   };
 

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -5,6 +5,7 @@ import Auth from '@/routes/auth';
 import GeneralLayout from '@/components/layout';
 import Plogging from '@/routes/plogging/index';
 import EndPlogging from './routes/endPlogging';
+import { PloggingProvider } from './api/context/ploggingContext';
 
 const routerData = [
   {
@@ -26,6 +27,7 @@ const routerData = [
     path: '/plogging',
     element: <Plogging />,
     withAuth: false,
+    withPlogging: true,
   },
   {
     path: '/endPlogging',
@@ -34,4 +36,18 @@ const routerData = [
   },
 ];
 
-export const routers = createBrowserRouter(routerData);
+export const routers = createBrowserRouter(
+  routerData.map(router => {
+    if (router.withPlogging) {
+      return {
+        path: router.path,
+        element: <PloggingProvider>{router.element}</PloggingProvider>,
+      };
+    } else {
+      return {
+        path: router.path,
+        element: router.element,
+      };
+    }
+  }),
+);

--- a/src/routes/plogging/index.jsx
+++ b/src/routes/plogging/index.jsx
@@ -7,20 +7,16 @@ import Trash from '@/components/plogging/trash';
 import Timer from '@/components/plogging/timer';
 
 import { ContentWrapper, GoPlogging, LogoImage } from './PloggingStyle';
+import { usePloggingStart } from '@/api/context/ploggingContext';
 
 export default function Plogging() {
-  const [isPlogging, setIsPlogging] = useState(false);
-  const [addTrashcan, setAddTrashcan] = useState(false);
+  const [isPloggingStarted, setIsPloggingStarted] = usePloggingStart();
 
   const handleStartPlogging = () => {
-    setIsPlogging(true);
+    setIsPloggingStarted(true);
   };
 
-  const handleEndPlogging = () => {
-    //  완료 화면으로 이동
-  };
-
-  const contentWrapperStyle = !isPlogging
+  const contentWrapperStyle = !isPloggingStarted
     ? { height: 'calc(100vh - 62px)' }
     : { height: '100vh' };
 
@@ -32,19 +28,19 @@ export default function Plogging() {
         </LogoImage>
         <KaKaoMap />
 
-        {!isPlogging && (
+        {!isPloggingStarted && (
           <GoPlogging onClick={handleStartPlogging}>
             <img src={startButton} width="312px" alt="start" />
           </GoPlogging>
         )}
-        {isPlogging && (
+        {isPloggingStarted && (
           <>
             <Trash />
             <Timer />
           </>
         )}
       </ContentWrapper>
-      {!isPlogging && <Navbar />}
+      {!isPloggingStarted && <Navbar />}
     </>
   );
 }


### PR DESCRIPTION
## :memo: 구현 내용

- 플로깅 경로 보여주기 기능 구현
  - 시작하기 버튼 눌러야 동작
  - 종료하기 > 네 눌러야 종료, 종료하기 > 아니오 일 경우 지속됨
- plogging route 범위에 적용되는 PloggingProvider 내부 전역으로 쓸 수 있는 useState들 추가(recoil 생각하시면 됩니다)
  - 플로깅 시작 여부 관장하는 usePloggingStart()
  - 플로깅 경로 값 관장하는 usePloggingValue()
  - 플로깅 경로 저장 관장하는 usePloggingActions()

## :heavy_exclamation_mark: 리뷰포인트

- Plogging 라우트 내에서 아래 세가지 훅들을 호출한 뒤 값을 바꿔주면 PloggingProvider 범위 내에 전체 일괄 적용됩니다.
- 사용 방법
```jsx
const [isPloggingStarted, setIsPloggingStarted] = usePloggingStart();
const ploggingData = usePloggingValue();
const add = usePloggingActions(); 
```

## :round_pushpin: 참고자료

- [다른 사람들이 안 알려주는 리액트에서 Context API 잘 쓰는 방법](https://velog.io/@velopert/react-context-tutorial)
